### PR TITLE
Fixed Duplicate Warmup Timers On Server

### DIFF
--- a/Tag/Source/Tag/Controller/TagPlayerController.cpp
+++ b/Tag/Source/Tag/Controller/TagPlayerController.cpp
@@ -129,7 +129,6 @@ void ATagPlayerController::HandleInMatch()
 	if (GameStartTimerRef != nullptr)
 	{
 		GameStartTimerRef->RemoveFromParent();
-		GameStartTimerRef = nullptr;
 	}
 }
 
@@ -155,7 +154,7 @@ void ATagPlayerController::HideScoreboard()
 
 void ATagPlayerController::StartGameStartCountdown()
 {
-	if (GameStartTimerClass && GameStartTimerRef == nullptr)
+	if (IsLocalController() && GameStartTimerClass && GameStartTimerRef == nullptr)
 	{
 		if (UGameStartTimer* GameStartTimer = CreateWidget<UGameStartTimer>(GetWorld(), GameStartTimerClass))
 		{


### PR DESCRIPTION
Fixed by checking if it was a local controller since server also has copies of client controllers. Similar fix may be required in other places.