### PR TITLE
Fixed Tag Indicator Not Appearing

### DIFF
--- a/Tag/Source/Tag/Character/TagCharacter.cpp
+++ b/Tag/Source/Tag/Character/TagCharacter.cpp
@@ -231,8 +231,16 @@ void ATagCharacter::CheckCouldTagSomeone(AActor* Actor, FAIStimulus Stimulus)
 
 	for (AActor* PerceivedActor : OutActors)
 	{
-		if (ATagCharacter* TagActor = Cast<ATagCharacter>(PerceivedActor); !TagActor->GetIsTagged())
+		const ATagCharacter* TagActor = Cast<ATagCharacter>(PerceivedActor);
+		if (!TagActor->GetIsTagged())
 		{
+			OnCouldTagSomeoneChangedDelegate.Broadcast(true);
+			Server_BroadcastCouldTagSomeone(true);
+			return;
+		}
+		else if (TagActor->GetIsTagged() && !GetIsTagged()) //For case where player is not tagged but if they were tagged by the tagged player they detect then they could tag someone.
+		{
+			UKismetSystemLibrary::PrintString(this, "Tagged Actor Detected");
 			OnCouldTagSomeoneChangedDelegate.Broadcast(true);
 			Server_BroadcastCouldTagSomeone(true);
 			return;
@@ -465,7 +473,7 @@ void ATagCharacter::PlayTagAnim() const
 	}
 }
 
-bool ATagCharacter::GetIsTagged()
+bool ATagCharacter::GetIsTagged() const
 {
 	if (!AbilitySystemComponent) return false;
 	const FGameplayTagContainer TagContainer = FGameplayTagContainer(FGameplayTag::RequestGameplayTag(FName("Effect.Tagged")));

--- a/Tag/Source/Tag/Character/TagCharacter.h
+++ b/Tag/Source/Tag/Character/TagCharacter.h
@@ -222,7 +222,7 @@ protected:
 
 public:
 	UFUNCTION(BlueprintCallable)
-	bool GetIsTagged();
+	bool GetIsTagged() const;
 	FORCEINLINE UTagCharacterMovementComponent* GetTagCharacterMovementComponent() const { return TagCharacterMovementComponent; }
 	FCollisionQueryParams GetIgnoreCharacterParams() const;
 	FORCEINLINE UAIPerceptionComponent* GetPerceptionComponent() const { return PerceptionComponent; }

--- a/Tag/Source/Tag/HUD/HUDElements/TaggedHUD/TagIndicator.cpp
+++ b/Tag/Source/Tag/HUD/HUDElements/TaggedHUD/TagIndicator.cpp
@@ -32,6 +32,6 @@ void UTagIndicator::SetupDelegate(APawn* OldPawn, APawn* NewPawn)
 void UTagIndicator::UpdateTagIndicator(bool bCouldTagSomeone)
 {
 	SetRenderOpacity(0.f);
-	if (!TagCharacter || !TagCharacter->GetIsTagged()) return;
+	if (!TagCharacter) return;
 	SetRenderOpacity(bCouldTagSomeone ? 1.f : 0.f);
 }


### PR DESCRIPTION
New case where a player tags someone but new tagger does not see tag indicator if the player who just tagged them is still in tagging range.