### PR TITLE
108 game timer shows 0 during warmup

### DIFF
--- a/Tag 5.3/.idea/.idea.Tag/.idea/copilot.data.migration.agent.xml
+++ b/Tag 5.3/.idea/.idea.Tag/.idea/copilot.data.migration.agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/Tag 5.3/.idea/.idea.Tag/.idea/copilot.data.migration.ask.xml
+++ b/Tag 5.3/.idea/.idea.Tag/.idea/copilot.data.migration.ask.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AskMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/Tag 5.3/.idea/.idea.Tag/.idea/copilot.data.migration.ask2agent.xml
+++ b/Tag 5.3/.idea/.idea.Tag/.idea/copilot.data.migration.ask2agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Ask2AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/Tag 5.3/.idea/.idea.Tag/.idea/copilot.data.migration.edit.xml
+++ b/Tag 5.3/.idea/.idea.Tag/.idea/copilot.data.migration.edit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EditMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/Tag 5.3/Source/Tag/GameStates/TagGameState.h
+++ b/Tag 5.3/Source/Tag/GameStates/TagGameState.h
@@ -57,4 +57,6 @@ public:
 	float LevelStartingTime = 0.f;
 	UPROPERTY(Replicated)
 	float RoundStartingTime = 0.f;
+
+	float GetCurrentRoundTime() const { return CurrentRoundTime; }
 };

--- a/Tag 5.3/Source/Tag/HUD/RoundHUD/RoundCountdownTimer.cpp
+++ b/Tag 5.3/Source/Tag/HUD/RoundHUD/RoundCountdownTimer.cpp
@@ -4,6 +4,7 @@
 #include "RoundCountdownTimer.h"
 
 #include "Components/TextBlock.h"
+#include "Kismet/KismetSystemLibrary.h"
 #include "Tag/GameStates/TagGameState.h"
 
 void URoundCountdownTimer::NativeConstruct()
@@ -14,13 +15,14 @@ void URoundCountdownTimer::NativeConstruct()
 	{
 		TagGameState->OnRoundStartedDelegate.AddDynamic(this, &URoundCountdownTimer::OnRoundStarted);
 		TagGameState->OnRoundEndedDelegate.AddDynamic(this, &URoundCountdownTimer::OnRoundEnded);
+		SetTimerText(TagGameState->GetCurrentRoundTime());
 	}
 }
 
 void URoundCountdownTimer::NativeTick(const FGeometry& MyGeometry, float InDeltaTime)
 {
 	Super::NativeTick(MyGeometry, InDeltaTime);
-	if (TagGameState)
+	if (TagGameState && bRoundActive)
 	{
 		const float ElapsedTime = TagGameState->GetServerWorldTimeSeconds()-StartTime;
 		float TimeLeft = TimePeriod - ElapsedTime;
@@ -33,12 +35,14 @@ void URoundCountdownTimer::OnRoundStarted(float RoundTime)
 {
 	TimePeriod = RoundTime;
 	if (TagGameState) StartTime = TagGameState->GetServerWorldTimeSeconds();
+	bRoundActive = true;
 }
 
 void URoundCountdownTimer::OnRoundEnded(float RoundIntervalTime)
 {
 	TimePeriod = RoundIntervalTime;
 	if (TagGameState) StartTime = TagGameState->GetServerWorldTimeSeconds();
+	bRoundActive = false;
 }
 
 

--- a/Tag 5.3/Source/Tag/HUD/RoundHUD/RoundCountdownTimer.h
+++ b/Tag 5.3/Source/Tag/HUD/RoundHUD/RoundCountdownTimer.h
@@ -38,4 +38,5 @@ private:
 	UPROPERTY()
 	ATagGameState* TagGameState;
 	void SetTimerText(const float Time) const;
+	bool bRoundActive = false;
 };


### PR DESCRIPTION
Fixed issue where game timer showed 0 during warmup. It now correctly shows the first round time and only starts the countdown when the round starts.